### PR TITLE
Update schema.lua

### DIFF
--- a/kong/plugins/path-prefix/schema.lua
+++ b/kong/plugins/path-prefix/schema.lua
@@ -1,7 +1,31 @@
+local typedefs = require "kong.db.schema.typedefs"
+
 return {
-  no_consumer = true,
+  name = "path-prefix",
   fields = {
-    path_prefix = {type = "string", required = true, },
-    escape = {type = "bool", default = true}
+    {
+      consumer = typedefs.no_consumer
+    },
+    {
+      run_on = typedefs.run_on_first
+    },
+    {
+      protocols = typedefs.protocols_http
+    },
+    {
+      config = {
+        type = "record",
+
+        fields = {
+
+          { path_prefix = {type = "string", required = true} },
+          { escape = {type = "boolean", default = true} },
+
+        }, 
+
+      },
+    },
+  },
+  entity_checks = {
   },
 }


### PR DESCRIPTION
Updated schema.lua for 1.x kong.
.. On 1.5 kong raise an exception: error loading plugin schemas: on plugin 'path-prefix': failed converting legacy schema for ...