### PR TITLE
Remove DB call to get service

### DIFF
--- a/kong/plugins/path-prefix/handler.lua
+++ b/kong/plugins/path-prefix/handler.lua
@@ -15,44 +15,10 @@ local function escape_hyphen(conf)
     return path_prefix
 end
 
-local function get_service_for_plugin(conf)
-    local service
-    local err
-
-    local service_id = conf.service_id
-
-    if not service_id and conf.route_id then
-        local route, err = kong.db.routes:select({ id = conf.route_id })
-        if err then
-            return nil, err
-        end
-
-        service_id = route.service_id
-    end
-
-    if not service_id then
-        return nil, "Unable to determine associated service"
-    end
-
-    return kong.db.services:select({ id = conf.service_id })
-end
-
 function plugin:access(plugin_conf)
     plugin.super.access(self)
 
-    local service, err = get_service_for_plugin(plugin_conf)
-
-    if err then
-        kong.log.err("Unable to determine service for plugin " .. err)
-        return kong.response.exit(500, "Internal server error")
-    end
-
-    -- ideally this plugin wouldn't need to do lookup the service's path,
-    -- but the path returned by kong.request.get_path() doesn't include it
-    -- and using kong.service.request.set_path will overwrite it (under the hood, get_path and set_path refer to different nginx vars).
-    -- more here: https://discuss.konghq.com/t/pdk-path-related-function-relative-to-router-matches-and-service-path/1329
-    local service_path = service.path or ""
-
+    local service_path = ngx.ctx.service.path or ""
     local full_path = kong.request.get_path()
     local replace_match = escape_hyphen(plugin_conf)
     local path_without_prefix = full_path:gsub(replace_match, "", 1)


### PR DESCRIPTION
This information is already in the nginx context, so I don't think we need to get it from the DB.  I ran into problems using this with `kong 2.5.x`.  I found that `conf.service_id` and `conf.route_id` were both nil.