### PR TITLE
Updated for kong 3.x

### DIFF
--- a/kong/plugins/path-prefix/handler.lua
+++ b/kong/plugins/path-prefix/handler.lua
@@ -1,8 +1,7 @@
-local plugin = require("kong.plugins.base_plugin"):extend()
-
-function plugin:new()
-    plugin.super.new(self, "path-prefix")
-end
+local plugin = {
+  PRIORITY = 800,
+  VERSION = "1.0.0"
+}
 
 local function escape_hyphen(conf)
     local path_prefix = conf.path_prefix
@@ -44,7 +43,5 @@ function plugin:access(plugin_conf)
     add_header(plugin_conf, path_without_prefix)
     kong.service.request.set_path(new_path)
 end
-
-plugin.PRIORITY = 800
 
 return plugin

--- a/kong/plugins/path-prefix/handler.lua
+++ b/kong/plugins/path-prefix/handler.lua
@@ -23,8 +23,6 @@ local function add_header(conf, path)
 end
 
 function plugin:access(plugin_conf)
-    plugin.super.access(self)
-
     local service_path = ngx.ctx.service.path or ""
     local full_path = kong.request.get_path()
     local replace_match = escape_hyphen(plugin_conf)


### PR DESCRIPTION
base_plugin has been deprecated in the latest version.  Resolves https://github.com/alexashley/kong-plugin-path-prefix/issues/12